### PR TITLE
Agreement on MS-OXPROPS PidTagClientActivelyEditingUntil structure has been added in the 20240416 version

### DIFF
--- a/MAPIInspector/Source/Parsers/MSOXPROPS.cs
+++ b/MAPIInspector/Source/Parsers/MSOXPROPS.cs
@@ -659,6 +659,11 @@ namespace MAPIInspector.Parsers
         PidTagClientActions = 0x6645,
 
         /// <summary>
+        /// Specifies the date and time, in UTC, until which the client expects to be actively editing the object.
+        /// </summary>
+        PidTagClientActivelyEditingUntil = 0x3700,
+
+        /// <summary>
         /// Contains the current time, in UTC, when the email message is submitted.
         /// </summary>
         PidTagClientSubmitTime = 0x0039,


### PR DESCRIPTION
Agreement on MS-OXPROPS PidTagClientActivelyEditingUntil structure has been added in the 20240416 version.